### PR TITLE
Some comments on the docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules;
 npm - debug.log.env.git.gitignore.dockerignore;
+
+# This needs more stuff. Do we need nodemon.json, readme etc in the image?

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
+# Why this node version? Is there a specific reason you're using 14 and not the LTS?
 FROM node:14
 
+# Why are you putting this in usr?
+# Your app code should probably live in its own folder on the image
 WORKDIR /usr/app
 
 COPY package*.json ./
 
 RUN npm install
 
+# Why copy the package.json to then copy everything later?
+# May as well copy everything at this point. If you were doing a multistage
+# I'd get it, this is just adding space to your image for no reason.
+# Remember, each layer is cached and produces size on the image
 COPY . .
 
+# Make this an arg. What if port 3000 is already in use?
+# ARG PORT=3000 makes the arg default to 3000
+# ENV PORT=$PORT uses the arg
+# EXPOSE $PORT
 EXPOSE 3000
 
 CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,35 @@
-version: "3"
+version: "3" # use latest version. I think it's 3.8
 services:
   app:
     build: .
+      # context: .
+      # dockerfile: Dockerfile - this is redundant, but useful if you move the dockerfile from the root
+      # args:
+      #   PORT: $APP_PORT - how we pass an env var to the image using compose
     volumes:
-      - .:/usr/app
+      - .:/usr/app # Love me a cheeky bind mount. Should the mysql folder be included though?
       - /usr/app/node_modules
     ports:
-      - "3000:3000"
-    command: npm start
+      - "3000:3000" # You cannot assume port 3000 on the host is free. Make the host port an env var
+    command: npm start # You specify this in the dockerfile. Definitely good to be specific though
     depends_on:
-      - mysql_server
+      - mysql_server # It's kinda redundant and slightly incorrect to refer to this as a server. Probs change server to db
     environment:
-      DB_HOST: mysql_server
+      DB_HOST: mysql_server # All of these should be env vars, maybe except notes_db
       DB_USER: root
       DB_PASSWORD: password
       DB_DATABASE: notes_db
 
   mysql_server:
-    image: mysql:5.7
+    image: mysql:5.7 # Why this version of mysql? Latest major is 8
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password # same as above environment block
       MYSQL_DATABASE: notes_db
     volumes:
       - ./mysql:/docker-entrypoint-initdb.d
+
+# You'll want a volumes key for the volume mount IRL. 
+# At the moment, you're binding the mysql folder in the 
+# container which might produce weirdness when using this starter
+
+# You should also have a network key. Using the default docker network is kinda a big no no in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
       # context: .
-      # dockerfile: Dockerfile - this is redundant, but useful if you move the dockerfile from the root
+      # dockerfile: Dockerfile - this is redundant in this case, but useful if you move the dockerfile from the root
       # args:
       #   PORT: $APP_PORT - how we pass an env var to the image using compose
     volumes:


### PR DESCRIPTION
# Feedback

## What I'd improve
- I don't get why mysql is all on its own. Your src includes references to it all over. I'd say include it. I mention this because the compose file mentions the init folder. Currently, you are putting all code in that folder in the container. I don't think you want this. Maybe separate out the sql files if you want to work this way
- Assuming ports are free is never a good idea. I'd always set these as args in the dockerfile and then use an env-file in the docker compose/ set the env vars manually.
- Be specific with the build key in the compose. It's very easy to mess yourself up with the dot context. Dot context means it takes your current folder as the place to run the builds and steps.
- You're using old versions of software. Node LTS is at 14. There is _almost_ no reason to use Node 14 (running node-sass is one exception I've encountered in the past). Unless you have a specific reason which I'm not sure you do here, always stick to the current LTS version of the image you are using.
- Dockerignore is missing some things. You're copying files into the image that don't really need to be there from what I can see.

## What I really like
- Use of the depends_on key. Makes start up of your containers make sense and prevent silly errors
- Using `docker-entrypoint-initdb.d` to run some set up sql. This is something that you could do in production in a pinch, though I wouldn't recommend. However, it is very common to copy config files for services like nginx into a container
- The dockerfile is short 👍 
- Good use of workdir. It's a common thing I always recommend and saves a layer
- Telling the image to expose a port. Means people don't have to use compose or set build args to use your image
- Specifying the command for the app service

## What I'd be aware of
- Naming services the same as what the folder they live in is called, app is also a very common name
- Hard coding ports in dockerfiles. This is never a good idea. Make use of env and arg. I left an example in your dockerfile
- Using current versions of compose. There are lots of cool features in compose that lead to Swarm being a very good orchestration mechanism for smaller projects (have a read about Docker Swarm, it's really cool)